### PR TITLE
feat: add recognition table views

### DIFF
--- a/elm_app/src/View/Icons.elm
+++ b/elm_app/src/View/Icons.elm
@@ -90,7 +90,7 @@ checked =
 add : Html msg
 add =
     svg
-        [ class "h-6 w-6 group-hover:text-blue-800 text-blue-600"
+        [ class "h-6 w-6 group-hover:text-blue-500 text-blue-600"
         , viewBox "0 0 20 20"
         , fill "currentColor"
         ]


### PR DESCRIPTION
Close https://github.com/SocialGouv/reva/issues/156

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/802010/146271565-b9686e3e-3c73-4436-bfe9-a01e0048abba.png">

Vous pouvez copier coller ces tableaux dans le template de reconnaissance (document Microsoft Word), ils s'afficheront aussi comme des tableaux :

<img width="1194" alt="image" src="https://user-images.githubusercontent.com/802010/146271599-208db681-9911-4e7e-a098-6af5ed0898be.png">
<img width="1213" alt="image" src="https://user-images.githubusercontent.com/802010/146271621-8d78da9d-e17c-4e3d-9334-6100776ebc45.png">
