### PR TITLE
fix(app): adapt the experience block height to its content

### DIFF
--- a/packages/reva-app/src/pages/ProjectExperiences.tsx
+++ b/packages/reva-app/src/pages/ProjectExperiences.tsx
@@ -32,7 +32,7 @@ const ExperiencePreview = (
 ) => (
   <li
     key={`experience-${index}`}
-    className="text-slate-800 rounded-lg bg-gray-100 h-64 py-2 px-8 space-y-4"
+    className="text-slate-800 rounded-lg bg-gray-100 pt-2 pb-10 px-8 space-y-4"
   >
     <div className="w-full flex items-center justify-between">
       <Title


### PR DESCRIPTION
Related #305 

![image](https://user-images.githubusercontent.com/802010/168887237-8101d986-2ba8-4d77-8344-ea5fb33a805a.png)
