### PR TITLE
feat(app): add organism selection to requirement and progress score

### DIFF
--- a/packages/reva-app/src/pages/SubmissionHome.tsx
+++ b/packages/reva-app/src/pages/SubmissionHome.tsx
@@ -1,11 +1,10 @@
 import { useActor } from "@xstate/react";
-import { AnimatePresence, isDragActive, motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { Interpreter } from "xstate";
 
 import { Button } from "../components/atoms/Button";
 import { Header } from "../components/atoms/Header";
 import { Loader } from "../components/atoms/Icons";
-import { BackButton } from "../components/molecules/BackButton";
 import { ProgressTitle } from "../components/molecules/ProgressTitle";
 import certificationImg from "../components/organisms/Card/certification.png";
 import { Page } from "../components/organisms/Page";

--- a/packages/reva-app/src/utils/projectProgress.tsx
+++ b/packages/reva-app/src/utils/projectProgress.tsx
@@ -1,4 +1,10 @@
-import { Certification, Contact, Experiences, Goal } from "../interface";
+import {
+  Certification,
+  Contact,
+  Experiences,
+  Goal,
+  Organism,
+} from "../interface";
 import { sortExperiences } from "./experienceHelpers";
 
 interface projectProgressProps {
@@ -6,6 +12,7 @@ interface projectProgressProps {
   contact?: Contact;
   experiences: Experiences;
   goals: Goal[];
+  organism?: Organism;
 }
 
 export function projectProgress({
@@ -13,6 +20,7 @@ export function projectProgress({
   contact,
   experiences,
   goals,
+  organism,
 }: projectProgressProps) {
   const hasCertification: boolean = certification !== undefined;
   const hasContact: boolean =
@@ -20,15 +28,17 @@ export function projectProgress({
     (contact?.email !== null || contact?.phone !== null);
   const hasExperiences: boolean = sortExperiences(experiences).length > 0;
   const hasGoals: boolean = goals.filter((goal) => goal.checked).length > 0;
+  const hasOrganism: boolean = organism !== undefined;
 
   const validations: boolean[] = [
     hasCertification,
     hasContact,
     hasExperiences,
     hasGoals,
+    hasOrganism,
   ];
 
   const validated: number = validations.filter((e) => e === true).length;
 
-  return (100 * validated) / 4;
+  return (100 * validated) / validations.length;
 }


### PR DESCRIPTION
When everything but the organism is selected, 80% and validation button disabled:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/802010/187868211-bc6f37c0-dc38-48e3-8f17-a94fed549741.png">
<img width="460" alt="image" src="https://user-images.githubusercontent.com/802010/187868263-ee273473-bf5a-4f1c-b4e7-47e43007bd53.png">

When organism is selected:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/802010/187868350-77e4dd6e-c47d-4848-8c99-f24f8929b1a6.png">
