### PR TITLE
fix(app): fix blocked button on mobile

### DIFF
--- a/packages/reva-app/src/App.tsx
+++ b/packages/reva-app/src/App.tsx
@@ -250,11 +250,11 @@ function App() {
   const appSize =
     windowSize.width > 640
       ? { width: 580, height: windowSize.height - 110 }
-      : // On mobile, this height prevents the fixed "candidate" button to be hidden behind Safari bar
-      ["certificateSummary", "certificateDetails"].some(current.matches)
-      ? windowSize
-      : // But on the other pages, it's better to keep 100vh (touching an input moves the view up)
-        { width: windowSize.width, height: "100vh" };
+      : // On mobile, for form pages it's better to keep 100vh (touching an input moves the view up)
+      ["loginHome", "projectExperience", "projectContact"].some(current.matches)
+      ? { width: windowSize.width, height: "100vh" }
+      : // Otherwise we use this height to prevent buttons fixed at the bottom to be hidden behind Safari bar
+        windowSize;
 
   const certificatesPage = (
     <Certificates key="show-results" mainService={mainService} />


### PR DESCRIPTION
There were more than the "candidate" button that is fixed at the bottom (like submit goal and submit candidacy).
By precaution, we now do the reverse: we keep the computed height by default and activate 100vh only for forms.

In the future, now we are also on desktop, we'll prevent the use of fixed button. 