### PR TITLE
test(app): fix random test failure on organisms

### DIFF
--- a/packages/reva-tests/cypress/e2e/organism.cy.js
+++ b/packages/reva-tests/cypress/e2e/organism.cy.js
@@ -78,7 +78,16 @@ context("Candidacy with region certification selected", () => {
       stubQuery(req, "getOrganismsForCandidacy", "organism.json");
       stubMutation(req, "candidacy_selectOrganism", "selected-organism.json");
     });
-    cy.login();
+
+    cy.login(
+      { token: "abc" },
+      {
+        onBeforeLoad(win) {
+          cy.stub(win.Math, "random").returns(0);
+        },
+      }
+    );
+
     cy.wait("@candidate_login");
 
     cy.get('[data-test="project-home-edit-organism').click();

--- a/packages/reva-tests/cypress/support/commands.js
+++ b/packages/reva-tests/cypress/support/commands.js
@@ -16,11 +16,11 @@ Cypress.Commands.add("auth", () => {
   });
 });
 
-Cypress.Commands.add("login", (config = { token: "abc" }) => {
+Cypress.Commands.add("login", (config = { token: "abc" }, options) => {
   cy.auth();
   if (config.token) {
-    cy.visit(`/login?token=${config.token}`);
+    cy.visit(`/login?token=${config.token}`, options);
   } else {
-    cy.visit(`/login`);
+    cy.visit(`/login`, options);
   }
 });


### PR DESCRIPTION
Tests need to be deterministic, so we are stubbing the Math.random function (as we would stub the API for stable responses).