### PR TITLE
fix(api): getOrganisms no longer crash when a candidacy has no certif…

### DIFF
--- a/packages/reva-api/infra/database/postgres/organisms.ts
+++ b/packages/reva-api/infra/database/postgres/organisms.ts
@@ -41,6 +41,7 @@ const getOrganisms = async (params: {
     const candidacy = await prismaClient.candidacy.findFirst({
       where: {
         id: params.candidacyId,
+        certificationsAndRegions: { some: {} },
       },
       include: {
         certificationsAndRegions: {


### PR DESCRIPTION
…icationsAndRegions (getCompanionsForCandidacy no longer crash either)