### PR TITLE
feat(api): alter funding_request_num_action_sequence with cycling

### DIFF
--- a/packages/reva-api/infra/database/postgres/fundingRequests.ts
+++ b/packages/reva-api/infra/database/postgres/fundingRequests.ts
@@ -143,11 +143,55 @@ export const createFundingRequest = async (params: {
 };
 
 const getNextNumAction = async () => {
-  const nextValQueryResult =
-    (await prismaClient.$queryRaw`Select nextval('funding_request_num_action_sequence')`) as {
+  const numActionSequenceNum = (await dayHasChangedSinceLastSequenceNumber())
+    ? await getResetSequenceNextVal()
+    : await getRegularSequenceNextVal();
+
+  const newNumAction = makeNumActionValueFromSequenceNum(numActionSequenceNum);
+  logger.info(`fundingRequest:getNextNumAction => ${newNumAction}`);
+  return newNumAction;
+};
+
+const dayHasChangedSinceLastSequenceNumber = async (): Promise<boolean> => {
+  const curSeqNum = (
+    (await prismaClient.$queryRaw`SELECT last_value FROM funding_request_num_action_sequence`) as Array<{
+      last_value: number;
+    }>
+  )[0].last_value;
+  const numAction = makeNumActionValueFromSequenceNum(curSeqNum);
+  logger.info(
+    `fundingRequest:getNextNumAction current seq. num=${curSeqNum}, looking up numAction ${numAction}`
+  );
+
+  const todaysRevaNumActionWithCurrentSeqNumCount =
+    await prismaClient.fundingRequest.count({
+      where: {
+        numAction,
+      },
+    });
+  const dayHasChanged = todaysRevaNumActionWithCurrentSeqNumCount === 0;
+  logger.info(
+    `fundingRequest:getNextNumAction numAction count: ${todaysRevaNumActionWithCurrentSeqNumCount}. must reset: ${dayHasChanged}`
+  );
+
+  return dayHasChanged;
+};
+
+const getResetSequenceNextVal = async (): Promise<number> => {
+  const sequenceStart = 1;
+  await prismaClient.$queryRaw`Select setval('funding_request_num_action_sequence',${sequenceStart})`;
+  return sequenceStart;
+};
+
+const getRegularSequenceNextVal = async (): Promise<number> => {
+  return (
+    (await prismaClient.$queryRaw`Select nextval('funding_request_num_action_sequence')`) as Array<{
       nextval: number;
-    }[];
-  return `reva_${format(new Date(), "yyyyMMdd")}_${nextValQueryResult[0].nextval
+    }>
+  )[0].nextval;
+};
+
+const makeNumActionValueFromSequenceNum = (sequenceNum: number) =>
+  `reva_${format(new Date(), "yyyyMMdd")}_${sequenceNum
     .toString()
     .padStart(5, "0")}`;
-};

--- a/packages/reva-api/prisma/migrations/20230110164319_alter_funding_request_sequence_to_cycle/migration.sql
+++ b/packages/reva-api/prisma/migrations/20230110164319_alter_funding_request_sequence_to_cycle/migration.sql
@@ -1,0 +1,5 @@
+-- This is an empty migration.
+ALTER SEQUENCE public.funding_request_num_action_sequence
+  MINVALUE 1
+  MAXVALUE 99999
+  CYCLE;


### PR DESCRIPTION
ETQ tech REVA, je veux que la sequence pour les id NumAction uniformation se reset tous les jours.
