### PR TITLE
feat(api): admins can manage candidacies

### DIFF
--- a/packages/reva-api/domain/features/canManageCandidacy.ts
+++ b/packages/reva-api/domain/features/canManageCandidacy.ts
@@ -19,16 +19,28 @@ export interface CanManageCandidacyDeps {
 interface CanManageCandidacyParams {
   candidacyId: string;
   keycloakId: string;
+  managerOnly?: boolean;
 }
 
 export const canManageCandidacy = async (
   deps: CanManageCandidacyDeps,
   params: CanManageCandidacyParams
 ): Promise<Either<string, boolean>> => {
-  if (!deps.hasRole("manage_candidacy")) {
-    return Right(false);
+  if(params.managerOnly) {
+    if (deps.hasRole("admin")) {
+      log('Admins are not authorized');
+      return Right(false);
+    }
+  } else {
+    if (deps.hasRole("admin")) {
+      log('User is admin, no further check');
+      return Right(true);
+    }
+    if (!deps.hasRole("manage_candidacy")) {
+      log('User is not manager');
+      return Right(false);
+    }
   }
-
   let candidacy, account;
   try {
     log("feature canManageCandidacy");

--- a/packages/reva-api/infra/graphql/candidacy/index.ts
+++ b/packages/reva-api/infra/graphql/candidacy/index.ts
@@ -312,7 +312,7 @@ export const resolvers = {
     },
 
     candidacy_deleteById: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(),
       async (_: unknown, payload: any) => {
         const result = await deleteCandidacy({
           deleteCandidacyFromId: candidacyDb.deleteCandidacyFromId,
@@ -329,7 +329,7 @@ export const resolvers = {
     ),
 
     candidacy_archiveById: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(),
       async (_: unknown, payload: any) => {
         const result = await archiveCandidacy({
           updateCandidacyStatus: candidacyDb.updateCandidacyStatus,
@@ -346,7 +346,7 @@ export const resolvers = {
     ),
 
     candidacy_updateAppointmentInformations: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(),
       async (_: unknown, payload: any) => {
         const result = await updateAppointmentInformations({
           updateAppointmentInformations:
@@ -366,7 +366,7 @@ export const resolvers = {
     ),
 
     candidacy_takeOver: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(true),
       async (_: unknown, payload: any, context: { auth: any }) => {
         const result = await takeOverCandidacy({
           hasRole: context.auth.hasRole,
@@ -374,7 +374,7 @@ export const resolvers = {
             candidacyDb.existsCandidacyWithActiveStatus,
           updateCandidacyStatus: candidacyDb.updateCandidacyStatus,
         })({
-          candidacyId: payload.candidacyId,
+          candidacyId: payload.candidacyId
         });
 
         return result
@@ -399,7 +399,7 @@ export const resolvers = {
         .extract();
     },
     candidacy_submitTrainingForm: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(),
       async (_: unknown, payload: any, context: { auth: any }) => {
         const result = await submitTraining({
           hasRole: context.auth.hasRole,
@@ -437,7 +437,7 @@ export const resolvers = {
         .extract();
     },
     candidacy_dropOut: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(),
       async (
         _: unknown,
         payload: {
@@ -474,7 +474,7 @@ export const resolvers = {
       }
     ),
     candidacy_updateAdmissibility: applySecurityCheckToResolver(
-      checkCanManageCandidacy,
+      checkCanManageCandidacy(),
       async (
         _: unknown,
         {

--- a/packages/reva-api/infra/graphql/security/user-can-manage-candidacy.ts
+++ b/packages/reva-api/infra/graphql/security/user-can-manage-candidacy.ts
@@ -17,7 +17,7 @@ import { SecurityCheck } from ".";
 
 const log = debug("gql");
 
-export const checkCanManageCandidacy: SecurityCheck = (
+export const checkCanManageCandidacy = (managerOnly?: boolean): SecurityCheck => (
   _: ResolverFirstArgument,
   payload: ResolverPayload,
   context: ResolverContext
@@ -31,7 +31,7 @@ export const checkCanManageCandidacy: SecurityCheck = (
         getAccountFromKeycloakId,
         getCandidacyFromId,
       },
-      { candidacyId, keycloakId }
+      { candidacyId, keycloakId, managerOnly }
     )
   )
     .mapLeft((err) => {


### PR DESCRIPTION
Admins are now allowed to perform mutations on candidacies, except for takeOver 