### PR TITLE
Change metabase buildpack to Scalingo managed buildpack

### DIFF
--- a/infra/metabase-scalingo/.buildpacks
+++ b/infra/metabase-scalingo/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/Scalingo/buildpack-jvm-common.git
-https://github.com/betagouv/metabase-buildpack
+https://github.com/Scalingo/metabase-buildpack.git

--- a/packages/reva-api/package.json
+++ b/packages/reva-api/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "create_auth_accounts": "npx ts-node --transpileOnly ./prisma/seed/certificateurs/create-accounts.ts | npx pino-pretty",
+    "create_auth_accounts_dry_run": "npx ts-node --transpileOnly ./prisma/seed/certificateurs/create-accounts.ts DRY_RUN | npx pino-pretty",
     "dev": "nodemon -e ts,json,graphql -w . ./index.ts | npx pino-pretty",
     "debug": "nodemon -e ts,json,graphql -w . --exec node --inspect-brk -r ts-node/register ./index.ts",
     "build": "npm run prisma:generate && npm run build:ts && npm run build:graphql",

--- a/packages/reva-api/prisma/seed/certificateurs/create-accounts.ts
+++ b/packages/reva-api/prisma/seed/certificateurs/create-accounts.ts
@@ -51,7 +51,11 @@ const createAccountForCertificationAuthority = (params: {
     username: cleanEmail(params.contactEmail),
   });
 
-async function createCertificationAuthoritiesAccounts() {
+async function createCertificationAuthoritiesAccounts({
+  dryRun,
+}: {
+  dryRun: boolean;
+}) {
   await keycloakAdmin.auth({
     grantType: "client_credentials",
     clientId: process.env.KEYCLOAK_ADMIN_CLIENTID || "admin-cli",
@@ -95,10 +99,24 @@ async function createCertificationAuthoritiesAccounts() {
     `Accounts for the following authorities will be created`
   );
 
+  if (!dryRun) {
+    for (const authority of authoritiesToCreateAccountFor) {
       logger.info(`creating account for ${authority.contactEmail}`);
+      (await createAccountForCertificationAuthority(authority)).mapLeft(
+        logger.error
+      );
+    }
   }
 }
 
 (async () => {
-  await createCertificationAuthoritiesAccounts();
+  const dryRun = process.argv[2] === "DRY_RUN";
+
+  logger.info(
+    "Running in " +
+      (dryRun
+        ? "DRY RUN MODE: Accounts WILL be created"
+        : "PRODUCTON MODE: Accounts will NOT be created")
+  );
+  await createCertificationAuthoritiesAccounts({ dryRun });
 })();


### PR DESCRIPTION
By default, it install the last version and you can choose the version with [METABASE_VERSION](https://github.com/Scalingo/metabase-buildpack#metabase_version)