### PR TITLE
Feat/reset status candidacy when updating diploma

### DIFF
--- a/packages/reva-api/modules/candidacy/features/submitCandidacy.ts
+++ b/packages/reva-api/modules/candidacy/features/submitCandidacy.ts
@@ -41,13 +41,13 @@ export const submitCandidacy =
         status: CandidacyStatusStep.PROJET,
       })
     )
-      .chain((existsCandidacy) => {
-        if (!existsCandidacy) {
+      .chain((candidacyInProject) => {
+        if (!candidacyInProject) {
           return EitherAsync.liftEither(
             Left(`Cette candidature ne peut être soumise à nouveau.`)
           );
         }
-        return EitherAsync.liftEither(Right(existsCandidacy));
+        return EitherAsync.liftEither(Right(candidacyInProject));
       })
       .mapLeft(
         (error: string) =>

--- a/packages/reva-api/modules/candidacy/features/submitCandidacy.ts
+++ b/packages/reva-api/modules/candidacy/features/submitCandidacy.ts
@@ -1,4 +1,4 @@
-import { Organism } from "@prisma/client";
+import { CandidacyStatusStep, Organism } from "@prisma/client";
 import { Either, EitherAsync, Left, Maybe, Right } from "purify-ts";
 
 import {
@@ -16,9 +16,9 @@ interface SubmitCandidacyDeps {
   getOrganismFromCandidacyId: (
     id: string
   ) => Promise<Either<string, Maybe<Organism>>>;
-  existsCandidacyHavingHadStatus: (params: {
+  existsCandidacyWithActiveStatus: (params: {
     candidacyId: string;
-    status: "VALIDATION";
+    status: typeof CandidacyStatusStep.PROJET;
   }) => Promise<Either<string, boolean>>;
   sendNewCandidacyEmail: (to: string) => Promise<Either<string, string>>;
 }
@@ -36,13 +36,13 @@ export const submitCandidacy =
     );
 
     const validateCandidacyNotAlreadySubmitted = EitherAsync.fromPromise(() =>
-      deps.existsCandidacyHavingHadStatus({
+      deps.existsCandidacyWithActiveStatus({
         candidacyId: params.candidacyId,
-        status: "VALIDATION",
+        status: CandidacyStatusStep.PROJET,
       })
     )
       .chain((existsCandidacy) => {
-        if (existsCandidacy) {
+        if (!existsCandidacy) {
           return EitherAsync.liftEither(
             Left(`Cette candidature ne peut être soumise à nouveau.`)
           );
@@ -57,7 +57,7 @@ export const submitCandidacy =
     const updateContact = EitherAsync.fromPromise(() =>
       deps.updateCandidacyStatus({
         candidacyId: params.candidacyId,
-        status: "VALIDATION",
+        status: CandidacyStatusStep.VALIDATION,
       })
     ).mapLeft(
       () =>

--- a/packages/reva-api/modules/candidacy/index.ts
+++ b/packages/reva-api/modules/candidacy/index.ts
@@ -274,8 +274,8 @@ const unsafeResolvers = {
       const result = await submitCandidacy({
         updateCandidacyStatus: candidacyDb.updateCandidacyStatus,
         getCandidacyFromId: candidacyDb.getCandidacyFromId,
-        existsCandidacyHavingHadStatus:
-          candidacyDb.existsCandidacyHavingHadStatus,
+        existsCandidacyWithActiveStatus:
+          candidacyDb.existsCandidacyWithActiveStatus,
         getOrganismFromCandidacyId:
           organismDb.getReferentOrganismFromCandidacyId,
         sendNewCandidacyEmail,

--- a/packages/reva-app/src/machines/main.machine.ts
+++ b/packages/reva-app/src/machines/main.machine.ts
@@ -445,6 +445,7 @@ export const mainMachine =
                     "submitCertification",
                     "resetOrganisms",
                     "resetFirstAppointmentOccuredAt",
+                    "resetCandidacyStatus",
                   ],
                   target: "#mainMachine.projectHome.ready",
                 },
@@ -1159,6 +1160,9 @@ export const mainMachine =
             Sentry.captureException(event.data),
           resetFirstAppointmentOccuredAt: assign({
             firstAppointmentOccuredAt: (_) => undefined,
+          }),
+          resetCandidacyStatus: assign({
+            candidacyStatus: (_) => "PROJET",
           }),
         },
         guards: {


### PR DESCRIPTION
**API** :
Implemented the switch in the DB for the candidacy status transition from "VALIDATION" to "PROJET" when a candidate changes their diploma.

**APP** :

Added functionality to reset the candidacy status within the xState framework.